### PR TITLE
feat: autenticação JWT, roles de admin, endpoints de administração, t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,30 @@
 # API de Login de Usuários
 
+## Histórico de Alterações
+
+- Implementação de autenticação JWT (Bearer Token) para todos os endpoints protegidos.
+- Adição de roles de usuário: `admin` e `user`.
+- Criação de usuários administradores: `admin@email.com`, `edcleryton.silva@email.com`, `jorge.mercado@email.com` (todos com senha `Admin123456!`).
+- Criação de endpoint PATCH `/admin/user` para administradores alterarem nome/senha de qualquer usuário.
+- Criação de endpoint DELETE `/user` para administradores deletarem qualquer usuário.
+- Apenas administradores podem alterar ou deletar outros usuários.
+- Separação dos testes automatizados em blocos distintos para garantir isolamento e clareza dos cenários (usuário comum, admin, permissões, etc).
+- Reset robusto do estado dos usuários antes de cada teste.
+- Documentação Swagger e exemplos de requisição atualizados.
+
 ## Documentação Swagger
 
 A documentação interativa da API está disponível em:
 
 [http://localhost:3000/api-docs](http://localhost:3000/api-docs)
 
-
 Basta iniciar a aplicação e acessar esse link no navegador para visualizar e testar todos os endpoints da API.
-=======
+
 ## Instalação
 ```bash
 cd mentoria_testes_desafio_03
 npm install
 ```
-
 
 ## Estrutura de Pastas
 
@@ -55,6 +65,27 @@ Execute:
 npm test
 ```
 
+## Usuários de exemplo
+
+> **Atenção:** As senhas estão explícitas para facilitar o estudo e os testes. **Nunca faça isso em produção!**
+
+- **admin@email.com** (admin)
+  - Senha: `Admin123456!`
+- **edcleryton.silva@email.com** (admin)
+  - Senha: `Admin123456!`
+- **jorge.mercado@email.com** (admin)
+  - Senha: `Admin123456!`
+- **user@email.com** (usuário comum)
+  - Senha: `User12345678!`
+
+## Autenticação
+
+A API utiliza autenticação do tipo **Bearer Token** (JWT). Para acessar endpoints protegidos, faça login e utilize o token retornado no header:
+
+```
+Authorization: Bearer <seu_token>
+```
+
 ## Exemplos de Requisições
 
 ### Cadastro de Usuário
@@ -72,8 +103,47 @@ Content-Type: application/json
 POST /login
 Content-Type: application/json
 {
-  "email": "usuario@email.com",
-  "password": "SenhaForte123!"
+  "email": "admin@email.com",
+  "password": "Admin123456!"
+}
+```
+**Resposta:**
+```json
+{
+  "message": "Login realizado com sucesso. Sessão criada.",
+  "token": "<jwt_token>"
+}
+```
+
+### Alterar senha do próprio usuário (autenticado)
+```http
+PATCH /user
+Authorization: Bearer <token>
+Content-Type: application/json
+{
+  "password": "NovaSenha12345!"
+}
+```
+
+### Alterar nome/senha de qualquer usuário (admin)
+```http
+PATCH /admin/user
+Authorization: Bearer <token_admin>
+Content-Type: application/json
+{
+  "username": "user@email.com",
+  "password": "NovaSenha12345!",
+  "newUsername": "novo@email.com" // opcional
+}
+```
+
+### Deletar usuário (admin)
+```http
+DELETE /user
+Authorization: Bearer <token_admin>
+Content-Type: application/json
+{
+  "username": "user@email.com"
 }
 ```
 
@@ -90,6 +160,7 @@ Content-Type: application/json
 - express
 - swagger-ui-express
 - swagger-jsdoc
+- jsonwebtoken
 - mocha (testes)
 - supertest (testes)
 
@@ -97,6 +168,7 @@ Content-Type: application/json
 - O arquivo `swagger.json` contém toda a documentação da API.
 - Para rodar a API em outra porta, defina a variável de ambiente `PORT`.
 - O cadastro exige email válido e senha forte (12-16 caracteres, maiúscula, minúscula, número e caractere especial).
+- Apenas administradores podem alterar ou deletar outros usuários.
+- **Nunca exponha senhas reais em código ou documentação em ambientes de produção!**
 
----
-Se precisar de mais informações, consulte o arquivo `swagger.json` ou a documentação em `/api-docs`. 
+--- 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "express": "^4.18.2",
+        "jsonwebtoken": "^9.0.2",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^4.6.3"
       },
@@ -276,6 +277,12 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -643,6 +650,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -1260,6 +1276,55 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -1283,6 +1348,18 @@
       "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
@@ -1290,10 +1367,40 @@
       "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.mergewith": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
       "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/log-symbols": {
@@ -1735,7 +1842,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -1,9 +1,7 @@
 {
   "name": "api-login-usuarios",
   "version": "1.0.0",
-
   "description": "API REST para gestão de login de usuários (desafio de testes)",
-
   "main": "app.js",
   "scripts": {
     "start": "node app.js",
@@ -21,13 +19,12 @@
   "license": "MIT",
   "dependencies": {
     "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.2",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^4.6.3"
   },
   "devDependencies": {
-
     "chai": "4.5.0",
-
     "mocha": "^10.2.0",
     "supertest": "^6.3.3"
   }

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -1,4 +1,5 @@
 const userService = require('../services/userService');
+const jwt = require('jsonwebtoken');
 
 function isValidEmail(email) {
   // Regex simples para validar email
@@ -28,8 +29,9 @@ exports.login = (req, res) => {
     return res.status(429).json({ message: 'Usuário bloqueado por excesso de tentativas.' });
   }
   if (result.status === 'success') {
-    // 201 Created para login bem-sucedido (sessão criada)
-    return res.status(201).json({ message: 'Login realizado com sucesso. Sessão criada.' });
+    // Geração do token JWT com role
+    const token = jwt.sign({ username, role: result.user.role }, 'secreta_super_segura', { expiresIn: '1h' });
+    return res.status(201).json({ message: 'Login realizado com sucesso. Sessão criada.', token });
   }
   return res.status(401).json({ message: 'Usuário ou senha inválidos.' });
 };
@@ -74,4 +76,72 @@ exports.register = (req, res) => {
     return res.status(201).json({ message: 'Usuário cadastrado com sucesso.' });
   }
   return res.status(400).json({ message: 'Dados inválidos.' });
+};
+
+exports.updateUser = (req, res) => {
+  const { password } = req.body;
+  const username = req.user.username;
+  if (!password) {
+    return res.status(400).json({ message: 'Senha é obrigatória.' });
+  }
+  if (!isStrongPassword(password)) {
+    return res.status(400).json({ message: 'A senha deve ter entre 12 e 16 caracteres, conter maiúsculas, minúsculas, números e caractere especial.' });
+  }
+  const result = userService.updatePassword(username, password);
+  if (result.status === 'not_found') {
+    return res.status(404).json({ message: 'Usuário não encontrado.' });
+  }
+  if (result.status === 'updated') {
+    return res.status(200).json({ message: 'Usuário atualizado com sucesso.' });
+  }
+  return res.status(400).json({ message: 'Erro ao atualizar usuário.' });
+};
+
+exports.updateUserByAdmin = (req, res) => {
+  console.log('updateUserByAdmin - req.user:', req.user);
+  console.log('updateUserByAdmin - req.body:', req.body);
+  const { username: targetUsername, password, newUsername } = req.body;
+  const { role } = req.user;
+  if (role !== 'admin') {
+    return res.status(403).json({ message: 'Apenas administradores podem alterar outros usuários.' });
+  }
+  if (!targetUsername) {
+    return res.status(400).json({ message: 'Username do usuário a ser alterado é obrigatório.' });
+  }
+  const newData = {};
+  if (password) {
+    if (!isStrongPassword(password)) {
+      return res.status(400).json({ message: 'A senha deve ter entre 12 e 16 caracteres, conter maiúsculas, minúsculas, números e caractere especial.' });
+    }
+    newData.password = password;
+  }
+  if (newUsername) {
+    if (!isValidEmail(newUsername)) {
+      return res.status(400).json({ message: 'Username (e-mail) inválido.' });
+    }
+    newData.username = newUsername;
+  }
+  const result = userService.updateUserByAdmin(targetUsername, newData);
+  if (result.status === 'not_found') {
+    return res.status(404).json({ message: 'Usuário não encontrado.' });
+  }
+  return res.status(200).json({ message: 'Usuário atualizado com sucesso.' });
+};
+
+exports.deleteUser = (req, res) => {
+  console.log('deleteUser - req.user:', req.user);
+  console.log('deleteUser - req.body:', req.body);
+  const { role } = req.user;
+  const { username: targetUsername } = req.body;
+  if (role !== 'admin') {
+    return res.status(403).json({ message: 'Apenas administradores podem deletar usuários.' });
+  }
+  if (!targetUsername) {
+    return res.status(400).json({ message: 'Username do usuário a ser deletado é obrigatório.' });
+  }
+  const result = userService.deleteUser(targetUsername);
+  if (result.status === 'not_found') {
+    return res.status(404).json({ message: 'Usuário não encontrado.' });
+  }
+  return res.status(200).json({ message: 'Usuário deletado com sucesso.' });
 }; 

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -1,13 +1,28 @@
 // Usuários de exemplo em memória
 const users = [
+  { username: 'admin@email.com', password: 'Admin123456!', blocked: false, attempts: 0, role: 'admin' },
+  { username: 'edcleryton.silva@email.com', password: 'Admin123456!', blocked: false, attempts: 0, role: 'admin' },
+  { username: 'jorge.mercado@email.com', password: 'Admin123456!', blocked: false, attempts: 0, role: 'admin' },
+  { username: 'user@email.com', password: 'User12345678!', blocked: false, attempts: 0, role: 'user' }
+];
 
-  { username: 'admin@email.com', password: 'Admin123456!', blocked: false, attempts: 0 },
-  { username: 'user@email.com', password: 'User12345678!', blocked: false, attempts: 0 }
+const initialUsers = [
+  { username: 'admin@email.com', password: 'Admin123456!', blocked: false, attempts: 0, role: 'admin' },
+  { username: 'edcleryton.silva@email.com', password: 'Admin123456!', blocked: false, attempts: 0, role: 'admin' },
+  { username: 'jorge.mercado@email.com', password: 'Admin123456!', blocked: false, attempts: 0, role: 'admin' },
+  { username: 'user@email.com', password: 'User12345678!', blocked: false, attempts: 0, role: 'user' }
 ];
 
 function findUser(username) {
   return users.find(u => u.username === username);
 }
+
+function resetUsers() {
+  users.length = 0;
+  initialUsers.forEach(u => users.push({ ...u }));
+}
+
+exports._reset = resetUsers;
 
 exports.login = (username, password) => {
   const user = findUser(username);
@@ -16,7 +31,7 @@ exports.login = (username, password) => {
   if (user.blocked) return { status: 'blocked' };
   if (user.password === password) {
     user.attempts = 0;
-    return { status: 'success' };
+    return { status: 'success', user };
   } else {
     user.attempts++;
     if (user.attempts >= 3) {
@@ -34,7 +49,7 @@ exports.register = (username, password) => {
   if (findUser(username)) {
     return { status: 'exists' };
   }
-  users.push({ username, password, blocked: false, attempts: 0 });
+  users.push({ username, password, blocked: false, attempts: 0, role: 'user' });
   return { status: 'created' };
 };
 
@@ -45,6 +60,30 @@ exports.rememberPassword = (username) => {
   // Simula envio de instrução de recuperação
   return { status: 'ok' };
 };
+
+exports.updatePassword = (username, newPassword) => {
+  const user = findUser(username);
+  if (!user) return { status: 'not_found' };
+  user.password = newPassword;
+  return { status: 'updated' };
+};
+
+exports.updateUserByAdmin = (targetUsername, newData) => {
+  const user = findUser(targetUsername);
+  if (!user) return { status: 'not_found' };
+  if (newData.username) user.username = newData.username;
+  if (newData.password) user.password = newData.password;
+  return { status: 'updated' };
+};
+
+exports.deleteUser = (username) => {
+  const idx = users.findIndex(u => u.username === username);
+  if (idx === -1) return { status: 'not_found' };
+  users.splice(idx, 1);
+  return { status: 'deleted' };
+};
+
+exports.getUser = findUser;
 
 // Método auxiliar para testes
 exports.__getUsers = () => users; 

--- a/swagger.json
+++ b/swagger.json
@@ -11,6 +11,13 @@
     }
   ],
   "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      }
+    },
     "schemas": {
       "LoginRequest": {
         "type": "object",
@@ -110,7 +117,20 @@
         },
         "responses": {
           "200": { "description": "OK. Login bem-sucedido." },
-          "201": { "description": "Created. Login realizado e sessão criada (caso aplicável)." },
+          "201": {
+            "description": "Created. Login realizado e sessão criada (caso aplicável).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": { "type": "string" },
+                    "token": { "type": "string", "description": "JWT de autenticação" }
+                  }
+                }
+              }
+            }
+          },
           "203": { "description": "Non-Authoritative Information. Login realizado, mas informações retornadas podem ser parciais." },
           "400": { "$ref": "#/components/responses/BadRequest" },
           "401": { "$ref": "#/components/responses/Unauthorized" },
@@ -166,6 +186,62 @@
           "201": { "description": "Created. Usuário cadastrado com sucesso." },
           "400": { "$ref": "#/components/responses/BadRequest" },
           "500": { "$ref": "#/components/responses/InternalServerError" }
+        }
+      }
+    },
+    "/admin/user": {
+      "patch": {
+        "summary": "Admin: Atualiza nome ou senha de qualquer usuário",
+        "security": [ { "bearerAuth": [] } ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "username": { "type": "string", "format": "email" },
+                  "password": { "type": "string", "minLength": 12, "maxLength": 16 },
+                  "newUsername": { "type": "string", "format": "email" }
+                },
+                "required": ["username"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Usuário atualizado com sucesso." },
+          "400": { "description": "Dados inválidos." },
+          "401": { "description": "Token não fornecido." },
+          "403": { "description": "Apenas administradores podem alterar outros usuários." },
+          "404": { "description": "Usuário não encontrado." }
+        }
+      }
+    },
+    "/user": {
+      "delete": {
+        "summary": "Admin: Deleta usuário",
+        "security": [ { "bearerAuth": [] } ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "username": { "type": "string", "format": "email" }
+                },
+                "required": ["username"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Usuário deletado com sucesso." },
+          "400": { "description": "Username do usuário a ser deletado é obrigatório." },
+          "401": { "description": "Token não fornecido." },
+          "403": { "description": "Apenas administradores podem deletar usuários." },
+          "404": { "description": "Usuário não encontrado." }
         }
       }
     }


### PR DESCRIPTION
alterações e implementações
Autenticação JWT (Bearer Token): Todos os endpoints protegidos agora exigem autenticação via token JWT.
Controle de permissões: Usuários possuem o campo role (admin ou user). Apenas administradores podem alterar ou deletar outros usuários.
Usuários administradores: Foram criados três admins (admin@email.com, edcleryton.silva@email.com, jorge.mercado@email.com), todos com senha Admin123456!.
Endpoints de administração:
PATCH /admin/user: Admin pode alterar nome e/ou senha de qualquer usuário.
DELETE /user: Admin pode deletar qualquer usuário.
Reset robusto de usuários: O método de reset restaura completamente o estado inicial dos usuários antes de cada teste.
Testes automatizados separados: Os testes foram organizados em blocos distintos para garantir isolamento e clareza:
Alteração de senha do usuário comum
Permissão de usuário comum em endpoints de admin
Funcionalidades de usuário comum
Funcionalidades de administrador
Documentação atualizada: README e Swagger refletem todos os endpoints, exemplos de uso, usuários e senhas de teste, e avisos de segurança.